### PR TITLE
fix: delete detail_page property from project save/update payload

### DIFF
--- a/src/pages/admin/components/ProjectsSection.jsx
+++ b/src/pages/admin/components/ProjectsSection.jsx
@@ -506,6 +506,9 @@ const ProjectsSection = () => {
                 projectData.additional_data.readme_file = projectData.detail_page || '';
             }
 
+            // Remove detail_page from projectData to keep the database payload clean
+            delete projectData.detail_page;
+
             let response;
 
             if (editingItem) {


### PR DESCRIPTION
- Remove the detail_page property from the projectData payload copy in handleSaveProject right before making API requests.
- Prevents sending temporary UI state properties used for rendering the markdown editor to backend DB queries.